### PR TITLE
Update repo path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ openSSL module as extension for chassis.io. See https://github.com/Chassis/Chass
 
 ## Usage
 
-1. Clone this into the `extensions` folder of your Chassis installation. Use recursive: `git clone --recursive https://github.com/javorszky/chassis-openssl.git` to get the submodule pulled in as well.
+1. Clone this into the `extensions` folder of your Chassis installation. Use recursive: `git clone --recursive https://github.com/Chassis/chassis-openssl.git` to get the submodule pulled in as well.
 1. Run `vagrant reload --provision` or just `vagrant up`
 1. Profit.
 


### PR DESCRIPTION
- Point the repo cloning instructions to `https://github.com/Chassis/chassis-openssl.git` instead of the javorsky remote.