### PR TITLE
Set owner and group to www-data

### DIFF
--- a/chassis.pp
+++ b/chassis.pp
@@ -7,12 +7,14 @@ openssl::certificate::x509 { $fqdn:
   altnames     => $openssl_config[hosts],
   extkeyusage  => [ 'serverAuth', 'clientAuth' ],
   cnf_tpl      => 'openssl-nginx/cert.cnf.erb',
-  days         => 3650
+  days         => 3650,
+  owner        => 'www-data',
+  group        => 'www-data',
 } ->
 file { "/vagrant/${fqdn}.cert":
-	ensure => present,
-	source => "/etc/ssl/certs/${fqdn}.crt",
-	mode => '0644',
+  ensure => present,
+  source => "/etc/ssl/certs/${fqdn}.crt",
+  mode => '0644',
 }
 
 include ::openssl-nginx


### PR DESCRIPTION
Nginx fails to restart as it cant read the .key file by default.