### PR TITLE
Add entries for all hosts in the array

### DIFF
--- a/modules/openssl-nginx/templates/cert.cnf.erb
+++ b/modules/openssl-nginx/templates/cert.cnf.erb
@@ -44,7 +44,8 @@ extendedKeyUsage = "<%= @extkeyusage.collect! {|x| "#{x}" }.join(', ') -%>"
 <% end -%>
 
 [ alt_names ]
-DNS.1 = <%= @fqdn %>
-DNS.2 = *.<%= @fqdn %>
+<% @altnames.each_with_index do |host,index| -%>
+DNS.<%= (index * 2) + 1 %> = <%= host %>
+DNS.<%= (index * 2) + 2 %> = *.<%= host %>
+<% end -%>
 <% end %>
-


### PR DESCRIPTION
Not sure why I did it but changing the cert to just use the FQDN as the cert domain was unneccessary - we can provide all configured domains.