### PR TITLE
Ability to reuse certificate for local dev servers

### DIFF
--- a/chassis.pp
+++ b/chassis.pp
@@ -16,5 +16,10 @@ file { "/vagrant/${fqdn}.cert":
   source => "/etc/ssl/certs/${fqdn}.crt",
   mode => '0644',
 }
+file { "/vagrant/${fqdn}.key":
+  ensure => present,
+  source => "/etc/ssl/certs/${fqdn}.key",
+  mode => '0644',
+}
 
 include ::openssl-nginx

--- a/chassis.pp
+++ b/chassis.pp
@@ -15,7 +15,7 @@ file { "/vagrant/${fqdn}.cert":
   ensure => present,
   source => "/etc/ssl/certs/${fqdn}.crt",
   mode => '0644',
-}
+} ->
 file { "/vagrant/${fqdn}.key":
   ensure => present,
   source => "/etc/ssl/certs/${fqdn}.key",

--- a/modules/openssl-nginx/templates/cert.cnf.erb
+++ b/modules/openssl-nginx/templates/cert.cnf.erb
@@ -44,6 +44,7 @@ extendedKeyUsage = "<%= @extkeyusage.collect! {|x| "#{x}" }.join(', ') -%>"
 <% end -%>
 
 [ alt_names ]
+DNS.0 = localhost
 <% @altnames.each_with_index do |host,index| -%>
 DNS.<%= (index * 2) + 1 %> = <%= host %>
 DNS.<%= (index * 2) + 2 %> = *.<%= host %>


### PR DESCRIPTION
This does two things:

1. Copies out .key file just like .cert so the certificate can be used outside the VM.
2. Includes `localhost` as an alternative name, so local dev servers, say webpack, can reuse the certificate to serve it's content. Saving developers time and eliminating the need to accept multiple certificates for the same host ( which often happens frequently ).